### PR TITLE
Fix docstrings monospace formatting

### DIFF
--- a/src/freshpointparser/__init__.py
+++ b/src/freshpointparser/__init__.py
@@ -1,4 +1,4 @@
-"""Main entry point for the `freshpointparser` package."""
+"""Main entry point for the ``freshpointparser`` package."""
 
 from . import exceptions, models, parsers
 from ._utils import get_location_page_url, get_product_page_url, logger

--- a/src/freshpointparser/_utils.py
+++ b/src/freshpointparser/_utils.py
@@ -9,7 +9,7 @@ from unidecode import unidecode
 from .exceptions import FreshPointParserTypeError, FreshPointParserValueError
 
 logger = logging.getLogger('freshpointparser')
-"""Top-level logger of the `freshpointparser` package."""
+"""Top-level logger of the ``freshpointparser`` package."""
 
 LOCATION_PAGE_URL = 'https://my.freshpoint.cz'
 
@@ -85,7 +85,7 @@ def get_location_page_url() -> str:
 def normalize_text(text: Any) -> str:  # noqa: ANN401
     """Normalize the given text by removing diacritics, leading/trailing
     whitespace, and converting it to lowercase. Non-string values are
-    converted to strings. `None` values are converted to empty strings.
+    converted to strings. ``None`` values are converted to empty strings.
 
     Args:
         text (Any): The text to be normalized.

--- a/src/freshpointparser/models/__init__.py
+++ b/src/freshpointparser/models/__init__.py
@@ -1,4 +1,4 @@
-"""Pydantic models and other data containers of the `freshpointparser` library.
+"""Pydantic models and other data containers of the ``freshpointparser`` library.
 The ``annotations`` submodule is available for additional data types.
 """
 

--- a/src/freshpointparser/models/_base.py
+++ b/src/freshpointparser/models/_base.py
@@ -39,7 +39,7 @@ else:
     from typing_extensions import TypeAlias
 
 logger = logging.getLogger('freshpointparser.models')
-"""Logger of the `freshpointparser.models` package."""
+"""Logger of the ``freshpointparser.models`` package."""
 
 _NoDefaultType = Enum('_NoDefaultType', 'NO_DEFAULT')
 _NO_DEFAULT = _NoDefaultType.NO_DEFAULT
@@ -145,8 +145,8 @@ def model_diff(left: BaseModel, right: BaseModel, **kwargs: Any) -> FieldDiffMap
         left (model): The model to compare.
         right (model): The model to compare with.
         **kwargs: Additional keyword arguments to pass to the ``model_dump``
-            calls to control the serialization process, such as `exclude`,
-            `include`, `by_alias`, and others.
+            calls to control the serialization process, such as ``exclude``,
+            ``include``, ``by_alias``, and others.
 
     Returns:
         FieldDiffMapping: A dictionary mapping field names to their differences,
@@ -188,7 +188,7 @@ def model_diff(left: BaseModel, right: BaseModel, **kwargs: Any) -> FieldDiffMap
 
 
 class HasRecordedAt(Protocol):
-    """Protocol for classes that have the `recorded_at` datetime attribute."""
+    """Protocol for classes that have the ``recorded_at`` datetime attribute."""
 
     recorded_at: datetime
     """Datetime when the data has been recorded."""
@@ -212,22 +212,22 @@ class BaseRecord(BaseModel):
         precision: Optional[Literal['s', 'm', 'h', 'd']] = None,
     ) -> Optional[bool]:
         """Check if this record is newer than another one by comparing
-        their `recorded_at` fields at the specified precision.
+        their ``recorded_at`` fields at the specified precision.
 
         Note that precision here means truncating the datetime to the desired
         level (e.g., cutting off seconds, minutes, etc.), not rounding it.
 
         Args:
             other (HasRecordedAt): The record to compare against. Must contain
-                the `recorded_at` datetime attribute.
+                the ``recorded_at`` datetime attribute.
             precision (Optional[Literal['s', 'm', 'h', 'd']]): The level of
                 precision for the comparison. Supported values:
 
-                - `None`: full precision (microsecond) (default)
-                - `s`: second precision
-                - `m`: minute precision
-                - `h`: hour precision
-                - `d`: date precision
+                - ``None``: full precision (microsecond) (default)
+                - ``s``: second precision
+                - ``m``: minute precision
+                - ``h``: hour precision
+                - ``d``: date precision
 
         Raises:
             FreshPointParserValueError: If the precision is not one of the supported values.
@@ -293,7 +293,7 @@ class BaseItem(BaseRecord):
         that it should not be recorded.
         """
         # This method could be a part of the BaseRecord class, but at the moment
-        # there are no use cases to exclude the `recorded_at` field there.
+        # there are no use cases to exclude the ``recorded_at`` field there.
         if not info.context:
             return value
         try:
@@ -335,8 +335,8 @@ class BaseItem(BaseRecord):
             exclude_recorded_at (bool): If True, the ``recorded_at`` field is
                 excluded from the comparison. Defaults to True.
             **kwargs: Additional keyword arguments passed to each item model's
-                ``model_dump`` call, such as `exclude`, `include`,
-                `by_alias`, and others.
+                ``model_dump`` call, such as ``exclude``, ``include``,
+                ``by_alias``, and others.
 
         Returns:
             FieldDiffMapping: A dictionary mapping field names to their
@@ -344,12 +344,12 @@ class BaseItem(BaseRecord):
 
             Each field difference is a dictionary
             (:class:`~freshpointparser.models.annotations.FieldDiff`) containing
-            the `type` and `values` keys.
+            the ``type`` and ``values`` keys.
 
-            - `type` (:class:`~freshpointparser.models.annotations.DiffType`): \
+            - ``type`` (:class:`~freshpointparser.models.annotations.DiffType`): \
             An enumeration value indicating the type of the difference.
 
-            - `values` (:class:`~freshpointparser.models.annotations.DiffValues`): \
+            - ``values`` (:class:`~freshpointparser.models.annotations.DiffValues`): \
             A pair of values - `left` from this model and `right` from the other \
             model. If a field is missing in one model, its value will be ``None``.
 
@@ -363,11 +363,11 @@ class BaseItem(BaseRecord):
             ...     },
             ...     'field_only_in_this': {
             ...         'type': DiffType.CREATED,
-            ...         'values': {'left': 'foo', 'right': None},
+            ...         'values': {'left': ``'foo'``, 'right': None},
             ...     },
             ...     'field_only_in_other': {
             ...         'type': DiffType.DELETED,
-            ...         'values': {'left': None, 'right': 'bar'},
+            ...         'values': {'left': None, 'right': ``'bar'``},
             ...     },
             ... }
 
@@ -449,17 +449,17 @@ class BasePage(BaseRecord, Generic[TItem]):
             exclude_recorded_at (bool): If True, the ``recorded_at`` field is
                 excluded from the comparison. Defaults to True.
             **kwargs: Additional keyword arguments passed to each item model's
-                ``model_dump`` call, such as `exclude`, `include`,
-                `by_alias`, and others.
+                ``model_dump`` call, such as ``exclude``, ``include``,
+                ``by_alias``, and others.
 
         Returns:
             ModelDiffMapping: A dictionary mapping numeric item IDs to their
             corresponding differences.
 
             Each dictionary value is a dictionary (ModelDiff) containing
-            the `type` and `diff` keys.
+            the ``type`` and `diff` keys.
 
-            - `type` (DiffType): An enumeration value indicating the type of \
+            - ``type`` (DiffType): An enumeration value indicating the type of \
             the difference (`Created`, `Updated`, or `Deleted`).
 
             - `diff` (FieldDiffMapping): A dictionary mapping field names to \
@@ -483,7 +483,7 @@ class BasePage(BaseRecord, Generic[TItem]):
             ...         'diff': {
             ...             'field_only_in_this': {
             ...                 'type': DiffType.DELETED,
-            ...                 'values': {'left': 'foo', 'right': None},
+            ...                 'values': {'left': ``'foo'``, 'right': None},
             ...             },
             ...         },
             ...     },
@@ -492,7 +492,7 @@ class BasePage(BaseRecord, Generic[TItem]):
             ...         'diff': {
             ...             'field_only_in_other': {
             ...                 'type': DiffType.CREATED,
-            ...                 'values': {'left': None, 'right': 'bar'},
+            ...                 'values': {'left': None, 'right': ``'bar'``},
             ...             },
             ...         },
             ...     },
@@ -632,8 +632,8 @@ class BasePage(BaseRecord, Generic[TItem]):
                 is the expected value. If a key is not present in the item, this
                 item is skipped.
 
-                Example: ``{'name': 'foo'}`` will match items where
-                the `name` attribute of the item is equal to `'foo'`.
+                Example: ``{'name': ``'foo'``}`` will match items where
+                the ``name`` attribute of the item is equal to ``'foo'``.
 
                 - Callable that receives an item instance and returns a boolean.
 
@@ -641,9 +641,9 @@ class BasePage(BaseRecord, Generic[TItem]):
                 argument, which is an instance of the item model, and return
                 a boolean value indicating whether the item meets the constraint.
 
-                Example: ``lambda item: 'foo' in item.name`` will match items
-                where the `name` attribute of the item contains the string
-                `'foo'`.
+                Example: ``lambda item: ``'foo'`` in item.name`` will match items
+                where the ``name`` attribute of the item contains the string
+                ``'foo'``.
 
         Raises:
             FreshPointParserTypeError: If the constraint is invalid, i.e., not a
@@ -674,8 +674,8 @@ class BasePage(BaseRecord, Generic[TItem]):
                 is the expected value. If a key is not present in the item, this
                 item is skipped.
 
-                Example: ``{'name': 'foo'}`` will match items where
-                the `name` attribute of the item is equal to `'foo'`.
+                Example: ``{'name': ``'foo'``}`` will match items where
+                the ``name`` attribute of the item is equal to ``'foo'``.
 
                 - Callable that receives an item instance and returns a boolean.
 
@@ -683,9 +683,9 @@ class BasePage(BaseRecord, Generic[TItem]):
                 argument, which is an instance of the item model, and return
                 a boolean value indicating whether the item meets the constraint.
 
-                Example: ``lambda item: 'foo' in item.name`` will match items
-                where the `name` attribute of the item contains the string
-                `'foo'`.
+                Example: ``lambda item: ``'foo'`` in item.name`` will match items
+                where the ``name`` attribute of the item contains the string
+                ``'foo'``.
 
         Raises:
             FreshPointParserTypeError: If the constraint is invalid, i.e., not a

--- a/src/freshpointparser/models/_product.py
+++ b/src/freshpointparser/models/_product.py
@@ -122,7 +122,7 @@ class Product(BaseItem):
     """Indicates whether the product is being promoted.
 
     **The product being a promo does not guarantee that the product currently
-    has a discount and vice versa.** Use `is_on_sale` to check if the product is
+    has a discount and vice versa.** Use ``is_on_sale`` to check if the product is
     on sale.
     """
     quantity: NonNegativeInt = Field(
@@ -173,7 +173,7 @@ class Product(BaseItem):
 
     def model_post_init(self, __context: object) -> None:
         """Post-initialization hook for the product model. Do not call directly.
-        Override with caution and call `super().model_post_init(__context)`.
+        Override with caution and call ``super().model_post_init(__context)``.
 
         :meta private:
 
@@ -233,7 +233,7 @@ class Product(BaseItem):
         """Compare the stock availability of the product in two different
         points in time.
 
-        This comparison is meaningful primarily when the `new` argument
+        This comparison is meaningful primarily when the ``new`` argument
         represents the same product at a different state or time, such as
         after a stock update.
 
@@ -273,7 +273,7 @@ class Product(BaseItem):
         """Compare the pricing details of the product in two different points
         in time.
 
-        This comparison is meaningful primarily when the `new` argument
+        This comparison is meaningful primarily when the ``new`` argument
         represents the same product but in a different pricing state, such as
         after a price adjustment.
 

--- a/src/freshpointparser/parsers/__init__.py
+++ b/src/freshpointparser/parsers/__init__.py
@@ -1,4 +1,4 @@
-"""FreshPoint webpage HTML parsers of the `freshpointparser` library."""
+"""FreshPoint webpage HTML parsers of the ``freshpointparser`` library."""
 
 from ._base import BasePageHTMLParser, logger
 from ._location import LocationPageHTMLParser, parse_location_page

--- a/src/freshpointparser/parsers/_base.py
+++ b/src/freshpointparser/parsers/_base.py
@@ -44,9 +44,9 @@ class BasePageHTMLParser(ABC, Generic[TPage]):
         Args:
             needle (str): String to search for.
             haystack (str): String to search in.
-            partial_match (bool): If True, checks if `needle` is a substring of
-                `haystack` (`needle in haystack`). If False, checks for exact
-                match (`needle == haystack`). In both cases, the match is
+            partial_match (bool): If True, checks if ``needle`` is a substring of
+                ``haystack`` (``needle in haystack``). If False, checks for exact
+                match (``needle == haystack``). In both cases, the match is
                 case-insensitive and ignores diacritics.
 
         Raises:

--- a/src/freshpointparser/parsers/_location.py
+++ b/src/freshpointparser/parsers/_location.py
@@ -18,7 +18,7 @@ from ._base import BasePageHTMLParser
 
 
 class LocationPageHTMLParser(BasePageHTMLParser[LocationPage]):
-    """Parses HTML content of a FreshPoint location webpage `my.freshpoint.cz`.
+    """Parses HTML content of a FreshPoint location webpage ``my.freshpoint.cz``.
     Allows accessing the parsed webpage data and searching for locations by name
     or ID.
     """
@@ -37,7 +37,7 @@ class LocationPageHTMLParser(BasePageHTMLParser[LocationPage]):
         r"""Extract and parse the JSON location data embedded in the HTML.
 
         The location data is stored in the page HTML as a JavaScript string
-        variable: `devices = "[{\"prop\":{...}}]";`
+        variable: ``devices = "[{\"prop\":{...}}]";``
 
         This method uses regex to find this variable assignment and extract
         the JSON string. A double JSON parsing approach is used because the data
@@ -148,7 +148,7 @@ class LocationPageHTMLParser(BasePageHTMLParser[LocationPage]):
         The returned ``Location`` instances are independent of the parser's
         cached data. Changes made to them will not modify the parser state.
         """
-        # page is fully parsed on `parse` call. Copy for cache immutability
+        # page is fully parsed on ``parse`` call. Copy for cache immutability
         return [loc.model_copy(deep=True) for loc in self._page.items.values()]
 
     def find_location_by_id(self, id_: Union[int, str]) -> Optional[Location]:
@@ -189,7 +189,7 @@ class LocationPageHTMLParser(BasePageHTMLParser[LocationPage]):
             name (str): The name of the location to search for. Note that
                 location names are normalized to lowercase ASCII characters.
                 The match is case-insensitive and ignores diacritics regardless
-                of the `partial_match` value.
+                of the ``partial_match`` value.
             partial_match (bool): If True, the name match can be partial
                 (case-insensitive). If False, the name match must be exact
                 (case-insensitive). Defaults to True.
@@ -207,7 +207,7 @@ class LocationPageHTMLParser(BasePageHTMLParser[LocationPage]):
             raise FreshPointParserTypeError(
                 f'Expected a string for location name, got {type(name)}.'
             )
-        # wrapper over `LocationPage.find_item` method
+        # wrapper over ``LocationPage.find_item`` method
         location = self._page.find_item(
             lambda loc: self._match_strings(name, loc.name, partial_match)
         )
@@ -224,7 +224,7 @@ class LocationPageHTMLParser(BasePageHTMLParser[LocationPage]):
             name (str): The name of the location to filter by. Note that location
                 names are normalized to lowercase ASCII characters. The match
                 is case-insensitive and ignores diacritics regardless of the
-                `partial_match` value.
+                ``partial_match`` value.
             partial_match (bool): If True, the name match can be partial
                 (case-insensitive). If False, the name match must be exact
                 (case-insensitive). Defaults to True.
@@ -241,7 +241,7 @@ class LocationPageHTMLParser(BasePageHTMLParser[LocationPage]):
             raise FreshPointParserTypeError(
                 f'Expected a string for location name, got {type(name)}.'
             )
-        # wrapper over `LocationPage.find_locations` method
+        # wrapper over ``LocationPage.find_locations`` method
         locations = self._page.find_items(
             lambda loc: self._match_strings(name, loc.name, partial_match)
         )
@@ -251,7 +251,7 @@ class LocationPageHTMLParser(BasePageHTMLParser[LocationPage]):
 
 def parse_location_page(page_html: Union[str, bytes]) -> LocationPage:
     """Parse the HTML content of a FreshPoint location webpage
-    `my.freshpoint.cz` to a structured LocationPage model.
+    ``my.freshpoint.cz`` to a structured LocationPage model.
 
     Args:
         page_html (Union[str, bytes]): HTML content of the location page.

--- a/src/freshpointparser/parsers/_product.py
+++ b/src/freshpointparser/parsers/_product.py
@@ -32,7 +32,7 @@ class ProductHTMLParser:
 
     This class provides static methods to parse various attributes of a product
     from its HTML representation. It's designed to work with BeautifulSoup
-    `Tag` objects, extracting data such as product name, ID number, pricing,
+    ``Tag`` objects, extracting data such as product name, ID number, pricing,
     availability, etc.
     """
 
@@ -46,15 +46,15 @@ class ProductHTMLParser:
         """Get a single Tag in a ResultSet.
 
         Args:
-            resultset (bs4.ResultSet): A `bs4.ResultSet` object
-                expected to contain exactly one `bs4.Tag` object.
+            resultset (bs4.ResultSet): A ``bs4.ResultSet`` object
+                expected to contain exactly one ``bs4.Tag`` object.
 
         Returns:
-            bs4.Tag: The Tag contained in the provided `resultset`.
+            bs4.Tag: The Tag contained in the provided ``resultset``.
 
         Raises:
-            FreshPointParserValueError: If `resultset` does not contain exactly one Tag.
-            FreshPointParserTypeError: If the extracted element is not a `bs4.Tag` object.
+            FreshPointParserValueError: If ``resultset`` does not contain exactly one Tag.
+            FreshPointParserTypeError: If the extracted element is not a ``bs4.Tag`` object.
         """
         if len(resultset) == 0:
             raise FreshPointParserValueError(
@@ -294,7 +294,7 @@ class ProductHTMLParser:
 
 class ProductPageHTMLParser(BasePageHTMLParser[ProductPage]):
     """Parses HTML content of a FreshPoint product webpage
-    `my.freshpoint.cz/device/product-list/<pageId>`. Allows accessing
+    ``my.freshpoint.cz/device/product-list/<pageId>``. Allows accessing
     the parsed webpage data and searching for products by name or ID.
     """
 
@@ -584,7 +584,7 @@ class ProductPageHTMLParser(BasePageHTMLParser[ProductPage]):
             name (str): The name of the product to search for. Note that product
                 names are normalized to lowercase ASCII characters. The match
                 is case-insensitive and ignores diacritics regardless of the
-                `partial_match` value.
+                ``partial_match`` value.
             partial_match (bool): If True, the name match can be partial
                 (case-insensitive). If False, the name match must be exact
                 (case-insensitive). Defaults to True.
@@ -625,7 +625,7 @@ class ProductPageHTMLParser(BasePageHTMLParser[ProductPage]):
             name (str): The name of the product to filter by. Note that product
                 names are normalized to lowercase ASCII characters. The match
                 is case-insensitive and ignores diacritics regardless of the
-                `partial_match` value.
+                ``partial_match`` value.
             partial_match (bool): If True, the name match can be partial
                 (case-insensitive). If False, the name match must be exact
                 (case-insensitive). Defaults to True.
@@ -659,7 +659,7 @@ class ProductPageHTMLParser(BasePageHTMLParser[ProductPage]):
 
 def parse_product_page(page_html: Union[str, bytes]) -> ProductPage:
     """Parse the HTML content of a FreshPoint product webpage
-    `my.freshpoint.cz/device/product-list/<pageId>` to a structured
+    ``my.freshpoint.cz/device/product-list/<pageId>`` to a structured
     ProductPage model.
 
     Args:


### PR DESCRIPTION
## Summary
- update docstrings to use double backticks
- ensure python literals in docstrings use monospace style

## Testing
- `pytest -q` *(fails: RuntimeError: Failed to fetch location from https://my.freshpoint.cz/device/product-list/2)*

------
https://chatgpt.com/codex/tasks/task_e_687290182b48832a9ba17f0a86a0277c