### PR TITLE
Update diff

### DIFF
--- a/src/freshpointparser/models/__init__.py
+++ b/src/freshpointparser/models/__init__.py
@@ -1,5 +1,5 @@
 """Pydantic models and other data containers of the ``freshpointparser`` library.
-The ``annotations`` submodule is available for additional data types.
+The ``types`` submodule is available for additional data types.
 """
 
 from . import types

--- a/src/freshpointparser/models/_base.py
+++ b/src/freshpointparser/models/_base.py
@@ -200,7 +200,7 @@ class BaseItem(BestEffortModel):
             corresponding difference pairs.
 
             Each field difference is a
-            (:class:`~freshpointparser.models.annotations.FieldDiff`) dictionary
+            (:class:`~freshpointparser.models.types.FieldDiff`) dictionary
             containing the ``left`` and ``right`` values from this model and the other
             model, respectively. If a field is missing in any of the models, its value
             is considered to be ``None`` in this model.

--- a/src/freshpointparser/models/_base.py
+++ b/src/freshpointparser/models/_base.py
@@ -282,7 +282,9 @@ class BasePage(BestEffortModel, Generic[TItem]):
         """Total number of items on the page."""
         return len(self.items)
 
-    def item_diff(self, other: BasePage[TItem], **kwargs: Any) -> ModelDiffMapping:
+    def item_diff(
+        self, other: BasePage[TItem], *, exclude_missing: bool = False, **kwargs: Any
+    ) -> ModelDiffMapping:
         """Compare items between this page and another one to identify which
         items differ. Items are matched by their ID.
 
@@ -295,6 +297,8 @@ class BasePage(BestEffortModel, Generic[TItem]):
 
         Args:
             other (BasePage): The page to compare against.
+            exclude_missing (bool): Whether to exclude items that are missing in
+                either page from the result.
             **kwargs: Additional keyword arguments passed to each item model's
                 ``model_dump`` call, such as ``exclude``, ``include``,
                 ``by_alias``, and others.
@@ -343,12 +347,17 @@ class BasePage(BestEffortModel, Generic[TItem]):
         # compare self to other
         for item_id, item_self in items_as_dict_self.items():
             item_other = items_as_dict_other.get(item_id, item_missing)
+            if item_other is item_missing and exclude_missing:
+                continue
             item_diff = item_self.model_diff(item_other, **kwargs)
             if item_diff:
                 diff[item_id] = item_diff
 
-        # compare other to self
-        if items_as_dict_other.keys() != items_as_dict_self.keys():
+        # compare other to self (only fields that are missing is self)
+        if (
+            items_as_dict_other.keys() != items_as_dict_self.keys()
+            and not exclude_missing
+        ):
             for item_id, item_other in items_as_dict_other.items():
                 if item_id not in items_as_dict_self:
                     # item_id not found => item_self is item_missing

--- a/src/freshpointparser/models/_base.py
+++ b/src/freshpointparser/models/_base.py
@@ -353,7 +353,7 @@ class BasePage(BestEffortModel, Generic[TItem]):
             if item_diff:
                 diff[item_id] = item_diff
 
-        # compare other to self (only fields that are missing is self)
+        # compare other to self (only items that are missing in self)
         if (
             items_as_dict_other.keys() != items_as_dict_self.keys()
             and not exclude_missing

--- a/src/freshpointparser/models/_base.py
+++ b/src/freshpointparser/models/_base.py
@@ -308,11 +308,11 @@ class BasePage(BestEffortModel, Generic[TItem]):
             corresponding differences.
 
             Each item difference is a
-            (:class:`~freshpointparser.models.annotations.FieldDiffMapping`) dictionary
+            (:class:`~freshpointparser.models.types.FieldDiffMapping`) dictionary
             that maps fields to the corresponding field differences.
 
             Each field difference is a
-            (:class:`~freshpointparser.models.annotations.FieldDiff`) dictionary
+            (:class:`~freshpointparser.models.types.FieldDiff`) dictionary
             containing the ``left`` and ``right`` values from this model and the other
             model, respectively. If a field is missing in any of the models, its value
             is considered to be ``None`` in this model.

--- a/src/freshpointparser/models/_base.py
+++ b/src/freshpointparser/models/_base.py
@@ -4,7 +4,6 @@ import logging
 import sys
 from datetime import date, datetime
 from enum import Enum
-from re import A
 from typing import (
     Any,
     Callable,
@@ -62,88 +61,6 @@ class ToCamel:
     def __call__(self, string: str) -> str:
         return to_camel(string)
 
-
-class EmptyModel(BaseModel):
-    """An empty Pydantic model with no fields."""
-
-    model_config = ConfigDict(frozen=True)
-
-
-_EMPTY_MODEL = EmptyModel()
-"""Singleton instance of an empty model."""
-
-
-# region Diff
-
-
-class FieldDiff(TypedDict):
-    """Typed dictionary to represent the left and the right value in
-    a difference comparison.
-    """
-
-    left: Any
-    """The left value in the pair."""
-    right: Any
-    """The right value in the pair."""
-
-
-FieldDiffMapping: TypeAlias = Dict[str, FieldDiff]
-"""Mapping of field names to their differences."""
-
-
-ModelDiffMapping: TypeAlias = Dict[str, FieldDiffMapping]
-"""Mapping of item IDs to their differences."""
-
-
-def model_diff(
-    left: BaseModel, right: BaseModel, model_dump_kwargs: Dict[str, Any]
-) -> FieldDiffMapping:
-    """Compare the left model with the right model to identify which model
-    fields have different values.
-
-    If a field exists in both items but its values differ, it is
-    marked as *Updated*. If the field is missing in this item, it is
-    considered to be *Created*, and if it is missing in the other item, it
-    is considered to be *Deleted*. If the field is not present in any of
-    the items, its value is considered to be ``None``.
-
-    The data is serialized according to the item models' configurations
-    using ``model_dump``.
-
-    Args:
-        left (model): The model to compare.
-        right (model): The model to compare with.
-        model_dump_kwargs (Dict[str, Any]): Additional keyword arguments to pass to
-            the ``model_dump`` calls to control the serialization process.
-
-    Returns:
-        FieldDiffMapping: A dictionary mapping field names to their differences,
-        each containing the diff type and a pair of left/right values.
-    """
-    if left is right:
-        return {}
-
-    left_asdict = left.model_dump(**model_dump_kwargs)
-    right_asdict = right.model_dump(**model_dump_kwargs)
-    diff = {}
-
-    # compare left to right
-    for field, value_left in left_asdict.items():
-        value_right = right_asdict.get(field, None)
-        if value_left != value_right:
-            diff[field] = FieldDiff(left=value_left, right=value_right)
-
-    # compare right to left
-    if right_asdict.keys() != left_asdict.keys():
-        for field, value_right in right_asdict.items():
-            value_left = left_asdict.get(field, None)
-            if value_left is None and value_right is not None:
-                diff[field] = FieldDiff(left=value_left, right=value_right)
-
-    return diff
-
-
-# endregion Diff
 
 # region BestEffortModel
 
@@ -234,6 +151,19 @@ class BestEffortModel(BaseModel):
 # region BaseItem
 
 
+class FieldDiff(TypedDict):
+    """Represents the difference for a single field between two models."""
+
+    left: Any
+    """The value from the left model."""
+    right: Any
+    """The value from the right model."""
+
+
+FieldDiffMapping: TypeAlias = Dict[str, FieldDiff]
+"""Mapping of field names to their difference pairs."""
+
+
 class BaseItem(BestEffortModel):
     """Base model of a FreshPoint item."""
 
@@ -249,15 +179,12 @@ class BaseItem(BestEffortModel):
     )
     """Unique item identifier (numeric unless undefined)."""
 
-    def diff(self, other: BaseItem, **kwargs: Any) -> FieldDiffMapping:
+    def model_diff(self, other: BaseItem, **kwargs: Any) -> FieldDiffMapping:
         """Compare this item with another one to identify which item fields
         have different values.
 
-        If a field exists in both items but its values differ, it is
-        marked as *Updated*. If the field is missing in this item, it is
-        considered to be *Created*, and if it is missing in the other item, it
-        is considered to be *Deleted*. If the field is not present in any of
-        the items, its value is considered to be ``None``.
+        If a field is not present in any of the models, its value is considered
+        to be ``None``.
 
         The data is serialized according to the item models' configurations
         using ``model_dump``.
@@ -270,39 +197,45 @@ class BaseItem(BestEffortModel):
 
         Returns:
             FieldDiffMapping: A dictionary mapping field names to their
-            corresponding differences.
+            corresponding difference pairs.
 
-            Each field difference is a dictionary
-            (:class:`~freshpointparser.models.annotations.FieldDiff`) containing
-            the ``type`` and ``values`` keys.
-
-            - ``type`` (:class:`~freshpointparser.models.annotations.DiffType`): \
-            An enumeration value indicating the type of the difference.
-
-            - ``values`` (:class:`~freshpointparser.models.annotations.DiffValues`): \
-            A pair of values - `left` from this model and `right` from the other \
-            model. If a field is missing in one model, its value will be ``None``.
+            Each field difference is a
+            (:class:`~freshpointparser.models.annotations.FieldDiff`) dictionary
+            containing the ``left`` and ``right`` values from this model and the other
+            model, respectively. If a field is missing in any of the models, its value
+            is considered to be ``None`` in this model.
 
             FieldDiffMapping structure example:
 
-            >>> from freshpointparser.models.annotations import DiffType
-            >>> {
-            ...     'field_common': {
-            ...         'type': DiffType.UPDATED,
-            ...         'values': {'left': 12.5, 'right': 15.0},
-            ...     },
-            ...     'field_only_in_this': {
-            ...         'type': DiffType.CREATED,
-            ...         'values': {'left': ``'foo'``, 'right': None},
-            ...     },
-            ...     'field_only_in_other': {
-            ...         'type': DiffType.DELETED,
-            ...         'values': {'left': None, 'right': ``'bar'``},
-            ...     },
-            ... }
-
+            ```python
+            {
+                'field_common': {'left': 12.5, 'right': 15.0},
+                'field_missing_in_other': {'left': 'foo', 'right': None},
+                'field_missing_in_self: {'left': None, 'right': 'bar'}
+            }
+            ```
         """
-        return model_diff(self, other, kwargs)
+        if self is other:
+            return {}
+
+        as_dict_self = self.model_dump(**kwargs)
+        as_dict_other = other.model_dump(**kwargs)
+        diff: FieldDiffMapping = {}
+
+        # compare self to other
+        for field, value_self in as_dict_self.items():
+            value_other = as_dict_other.get(field, None)
+            if value_self != value_other:
+                diff[field] = FieldDiff(left=value_self, right=value_other)
+
+        # compare other to self
+        if as_dict_other.keys() != as_dict_self.keys():
+            for field, value_other in as_dict_other.items():
+                value_self = as_dict_self.get(field, None)
+                if value_self is None and value_other is not None:
+                    diff[field] = FieldDiff(left=value_self, right=value_other)
+
+        return diff
 
 
 # endregion BaseItem
@@ -318,6 +251,10 @@ TItem = TypeVar(
     # default=BaseItem,
 )
 """Type variable to annotate item models."""
+
+
+ModelDiffMapping: TypeAlias = Dict[str, FieldDiffMapping]
+"""Mapping of item IDs to their differences."""
 
 
 class BasePage(BestEffortModel, Generic[TItem]):
@@ -349,11 +286,9 @@ class BasePage(BestEffortModel, Generic[TItem]):
         """Compare items between this page and another one to identify which
         items differ. Items are matched by their ID.
 
-        If an item exists in both pages but its field values differ, it is
-        marked as *Updated*. If the item is missing in this page, it is
-        considered to be *Created*, and if it is missing in the other page, it
-        is considered to be *Deleted*. If the item is not present in any of
-        the pages, its fields are considered to be ``None``.
+        If a field of any item is not present in any of the models, the value of
+        that field is considered to be ``None``. If an item is missing in either
+        page, all fields of that item are considered to be ``None``.
 
         The data is serialized according to the item models' configurations
         using ``model_dump``.
@@ -368,64 +303,47 @@ class BasePage(BestEffortModel, Generic[TItem]):
             ModelDiffMapping: A dictionary mapping numeric item IDs to their
             corresponding differences.
 
-            Each dictionary value is a dictionary (ModelDiff) containing
-            the ``type`` and `diff` keys.
+            Each item difference is a
+            (:class:`~freshpointparser.models.annotations.FieldDiffMapping`) dictionary
+            that maps fields to the corresponding field differences.
 
-            - ``type`` (DiffType): An enumeration value indicating the type of \
-            the difference (`Created`, `Updated`, or `Deleted`).
+            Each field difference is a
+            (:class:`~freshpointparser.models.annotations.FieldDiff`) dictionary
+            containing the ``left`` and ``right`` values from this model and the other
+            model, respectively. If a field is missing in any of the models, its value
+            is considered to be ``None`` in this model.
 
-            - `diff` (FieldDiffMapping): A dictionary mapping field names to \
-            `FieldDiff` entries, as described in `BaseItem.diff()`.
+            ModelDiffMapping structure example:
 
-            ModelDiff structure example:
-
-            >>> from freshpointparser.models.annotations import DiffType
-            >>> {
-            ...     '1001': {
-            ...         'type': DiffType.UPDATED,
-            ...         'diff': {
-            ...             'field_common': {
-            ...                 'type': DiffType.UPDATED,
-            ...                 'values': {'left': 12.5, 'right': 15.0},
-            ...             },
-            ...         },
-            ...     },
-            ...     '1002': {
-            ...         'type': DiffType.DELETED,
-            ...         'diff': {
-            ...             'field_only_in_this': {
-            ...                 'type': DiffType.DELETED,
-            ...                 'values': {'left': ``'foo'``, 'right': None},
-            ...             },
-            ...         },
-            ...     },
-            ...     '1003': {
-            ...         'type': DiffType.CREATED,
-            ...         'diff': {
-            ...             'field_only_in_other': {
-            ...                 'type': DiffType.CREATED,
-            ...                 'values': {'left': None, 'right': ``'bar'``},
-            ...             },
-            ...         },
-            ...     },
-            ... }
+            ```python
+            {
+                '1001': {
+                    'field_common': {'left': 12.5, 'right': 15.0},
+                    'field_missing_in_other': {'left': 'foo', 'right': None},
+                },
+                '1002': {
+                    'field_common': {'left': 10.0, 'right': 12.0},
+                    'field_missing_in_self': {'left': None, 'right': 'qux'},
+                },
+            }
+            ```
         """
+        if self is other:
+            return {}
+
         items_as_dict_self = {
             item.id_: item for item in self.items if item.id_ is not None
         }
         items_as_dict_other = {
             item.id_: item for item in other.items if item.id_ is not None
         }
-        item_missing = _EMPTY_MODEL
+        item_missing = BaseItem()
         diff: ModelDiffMapping = {}
 
         # compare self to other
         for item_id, item_self in items_as_dict_self.items():
-            item_other = items_as_dict_other.get(item_id, None)
-            if item_other is None:
-                item_diff = model_diff(item_self, item_missing, kwargs)
-            else:
-                item_diff = model_diff(item_self, item_other, kwargs)
+            item_other = items_as_dict_other.get(item_id, item_missing)
+            item_diff = item_self.model_diff(item_other, **kwargs)
             if item_diff:
                 diff[item_id] = item_diff
 
@@ -433,7 +351,8 @@ class BasePage(BestEffortModel, Generic[TItem]):
         if items_as_dict_other.keys() != items_as_dict_self.keys():
             for item_id, item_other in items_as_dict_other.items():
                 if item_id not in items_as_dict_self:
-                    item_diff = model_diff(item_missing, item_other, kwargs)
+                    # item_id not found => item_self is item_missing
+                    item_diff = item_missing.model_diff(item_other, **kwargs)
                     if item_diff:
                         diff[item_id] = item_diff
 

--- a/src/freshpointparser/models/_base.py
+++ b/src/freshpointparser/models/_base.py
@@ -211,7 +211,7 @@ class BaseItem(BestEffortModel):
             {
                 'field_common': {'left': 12.5, 'right': 15.0},
                 'field_missing_in_other': {'left': 'foo', 'right': None},
-                'field_missing_in_self: {'left': None, 'right': 'bar'}
+                'field_missing_in_self': {'left': None, 'right': 'bar'}
             }
             ```
         """

--- a/src/freshpointparser/models/_base.py
+++ b/src/freshpointparser/models/_base.py
@@ -211,7 +211,7 @@ class BaseItem(BestEffortModel):
             {
                 'field_common': {'left': 12.5, 'right': 15.0},
                 'field_missing_in_other': {'left': 'foo', 'right': None},
-                'field_missing_in_self': {'left': None, 'right': 'bar'}
+                'field_missing_in_self': {'left': None, 'right': 'bar'},
             }
             ```
         """
@@ -228,12 +228,12 @@ class BaseItem(BestEffortModel):
             if value_self != value_other:
                 diff[field] = FieldDiff(left=value_self, right=value_other)
 
-        # compare other to self
-        if as_dict_other.keys() != as_dict_self.keys():
-            for field, value_other in as_dict_other.items():
-                value_self = as_dict_self.get(field, None)
-                if value_self is None and value_other is not None:
-                    diff[field] = FieldDiff(left=value_self, right=value_other)
+        # compare other to self (only missing fields)
+        fields_missing_in_self = as_dict_other.keys() - as_dict_self.keys()
+        for field in fields_missing_in_self:
+            value_other = as_dict_other[field]
+            if value_other is not None:
+                diff[field] = FieldDiff(left=None, right=value_other)
 
         return diff
 
@@ -354,16 +354,15 @@ class BasePage(BestEffortModel, Generic[TItem]):
                 diff[item_id] = item_diff
 
         # compare other to self (only items that are missing in self)
-        if (
-            items_as_dict_other.keys() != items_as_dict_self.keys()
-            and not exclude_missing
-        ):
-            for item_id, item_other in items_as_dict_other.items():
-                if item_id not in items_as_dict_self:
-                    # item_id not found => item_self is item_missing
-                    item_diff = item_missing.model_diff(item_other, **kwargs)
-                    if item_diff:
-                        diff[item_id] = item_diff
+        if not exclude_missing:
+            item_ids_missing_in_self = (
+                items_as_dict_other.keys() - items_as_dict_self.keys()
+            )
+            for item_id in item_ids_missing_in_self:
+                item_other = items_as_dict_other[item_id]
+                item_diff = item_missing.model_diff(item_other, **kwargs)
+                if item_diff:
+                    diff[item_id] = item_diff
 
         return diff
 

--- a/src/freshpointparser/models/_base.py
+++ b/src/freshpointparser/models/_base.py
@@ -4,6 +4,7 @@ import logging
 import sys
 from datetime import date, datetime
 from enum import Enum
+from re import A
 from typing import (
     Any,
     Callable,
@@ -75,20 +76,7 @@ _EMPTY_MODEL = EmptyModel()
 # region Diff
 
 
-class DiffType(str, Enum):
-    """String enumeration of the types of differences between two items."""
-
-    CREATED = 'Created'
-    """The left item is missing"""
-
-    UPDATED = 'Updated'
-    """The right item is different from the left item."""
-
-    DELETED = 'Deleted'
-    """The right item is missing."""
-
-
-class DiffValues(TypedDict):
+class FieldDiff(TypedDict):
     """Typed dictionary to represent the left and the right value in
     a difference comparison.
     """
@@ -99,40 +87,16 @@ class DiffValues(TypedDict):
     """The right value in the pair."""
 
 
-class FieldDiff(TypedDict):
-    """Typed dictionary to represent the difference between two fields
-    in a model comparison.
-    """
-
-    type: DiffType
-    """The type of the difference."""
-    values: DiffValues
-    """The left and the right values in the difference comparison."""
-
-
 FieldDiffMapping: TypeAlias = Dict[str, FieldDiff]
 """Mapping of field names to their differences."""
 
 
-class ModelDiff(TypedDict):
-    """Typed dictionary to represent the difference between two models
-    in a model comparison.
-    """
-
-    type: DiffType
-    """The type of the difference."""
-    diff: FieldDiffMapping
-    """Mapping of field names to their differences."""
-
-
-ModelDiffMapping: TypeAlias = Dict[str, ModelDiff]
+ModelDiffMapping: TypeAlias = Dict[str, FieldDiffMapping]
 """Mapping of item IDs to their differences."""
 
 
 def model_diff(
-    left: BaseModel,
-    right: BaseModel,
-    model_dump_kwargs: Dict[str, Any],
+    left: BaseModel, right: BaseModel, model_dump_kwargs: Dict[str, Any]
 ) -> FieldDiffMapping:
     """Compare the left model with the right model to identify which model
     fields have different values.
@@ -165,28 +129,16 @@ def model_diff(
 
     # compare left to right
     for field, value_left in left_asdict.items():
-        if field in right_asdict:
-            diff_type = DiffType.UPDATED
-            value_right = right_asdict[field]
-        else:
-            diff_type = DiffType.DELETED
-            value_right = None
+        value_right = right_asdict.get(field, None)
         if value_left != value_right:
-            diff[field] = FieldDiff(
-                type=diff_type,
-                values=DiffValues(left=value_left, right=value_right),
-            )
+            diff[field] = FieldDiff(left=value_left, right=value_right)
 
     # compare right to left
     if right_asdict.keys() != left_asdict.keys():
         for field, value_right in right_asdict.items():
-            if field not in left_asdict:
-                diff_type = DiffType.CREATED
-                value_left = None
-                diff[field] = FieldDiff(
-                    type=diff_type,
-                    values=DiffValues(left=value_left, right=value_right),
-                )
+            value_left = left_asdict.get(field, None)
+            if value_left is None and value_right is not None:
+                diff[field] = FieldDiff(left=value_left, right=value_right)
 
     return diff
 
@@ -470,26 +422,20 @@ class BasePage(BestEffortModel, Generic[TItem]):
         # compare self to other
         for item_id, item_self in items_as_dict_self.items():
             item_other = items_as_dict_other.get(item_id, None)
-
             if item_other is None:
-                item_diff_type = DiffType.DELETED
                 item_diff = model_diff(item_self, item_missing, kwargs)
             else:
-                item_diff_type = DiffType.UPDATED
                 item_diff = model_diff(item_self, item_other, kwargs)
-
             if item_diff:
-                diff[item_id] = ModelDiff(type=item_diff_type, diff=item_diff)
+                diff[item_id] = item_diff
 
         # compare other to self
         if items_as_dict_other.keys() != items_as_dict_self.keys():
             for item_id, item_other in items_as_dict_other.items():
                 if item_id not in items_as_dict_self:
-                    item_diff_type = DiffType.CREATED
                     item_diff = model_diff(item_missing, item_other, kwargs)
-
                     if item_diff:
-                        diff[item_id] = ModelDiff(type=item_diff_type, diff=item_diff)
+                        diff[item_id] = item_diff
 
         return diff
 

--- a/src/freshpointparser/models/types.py
+++ b/src/freshpointparser/models/types.py
@@ -1,11 +1,8 @@
 """Annotations and auxiliary types for FreshPoint data models."""
 
 from ._base import (
-    DiffType,
-    DiffValues,
     FieldDiff,
     FieldDiffMapping,
-    ModelDiff,
     ModelDiffMapping,
 )
 from ._location import (
@@ -17,12 +14,9 @@ from ._product import (
 )
 
 __all__ = [
-    'DiffType',
-    'DiffValues',
     'FieldDiff',
     'FieldDiffMapping',
     'LocationCoordinates',
-    'ModelDiff',
     'ModelDiffMapping',
     'ProductPriceUpdateInfo',
     'ProductQuantityUpdateInfo',

--- a/src/freshpointparser/models/types.py
+++ b/src/freshpointparser/models/types.py
@@ -4,6 +4,7 @@ from ._base import (
     FieldDiff,
     FieldDiffMapping,
     ModelDiffMapping,
+    ValidationContext,
 )
 from ._location import (
     LocationCoordinates,
@@ -20,4 +21,5 @@ __all__ = [
     'ModelDiffMapping',
     'ProductPriceUpdateInfo',
     'ProductQuantityUpdateInfo',
+    'ValidationContext',
 ]

--- a/tests/models/test_models_product.py
+++ b/tests/models/test_models_product.py
@@ -11,7 +11,6 @@ from freshpointparser.exceptions import (
 )
 from freshpointparser.models import Product, ProductPage
 from freshpointparser.models.types import (
-    DiffType,
     ProductPriceUpdateInfo,
     ProductQuantityUpdateInfo,
 )
@@ -240,22 +239,10 @@ def test_product_prop_availability():
             Product(id_='123', name='foo', quantity=0, price_full=5),
             Product(id_='321', name='bar', quantity=5, price_full=10),
             {
-                'id_': {
-                    'type': DiffType.UPDATED,
-                    'values': {'left': '123', 'right': '321'},
-                },
-                'name': {
-                    'type': DiffType.UPDATED,
-                    'values': {'left': 'foo', 'right': 'bar'},
-                },
-                'quantity': {
-                    'type': DiffType.UPDATED,
-                    'values': {'left': 0, 'right': 5},
-                },
-                'price_full': {
-                    'type': DiffType.UPDATED,
-                    'values': {'left': 5, 'right': 10},
-                },
+                'id_': {'left': '123', 'right': '321'},
+                'name': {'left': 'foo', 'right': 'bar'},
+                'quantity': {'left': 0, 'right': 5},
+                'price_full': {'left': 5, 'right': 10},
             },
             id='different products',
         ),
@@ -263,10 +250,7 @@ def test_product_prop_availability():
             Product(id_='123', category='foo'),
             Product(id_='123', category='bar'),
             {
-                'category': {
-                    'type': DiffType.UPDATED,
-                    'values': {'left': 'foo', 'right': 'bar'},
-                }
+                'category': {'left': 'foo', 'right': 'bar'},
             },
             id='different category',
         ),
@@ -280,10 +264,7 @@ def test_product_prop_availability():
             Product(id_='123', quantity=4, price_full=10, price_curr=10),
             Product(id_='123', quantity=4, price_full=10, price_curr=5),
             {
-                'price_curr': {
-                    'type': DiffType.UPDATED,
-                    'values': {'left': 10, 'right': 5},
-                }
+                'price_curr': {'left': 10, 'right': 5},
             },
             id='same product, different price_curr',
         ),
@@ -291,10 +272,7 @@ def test_product_prop_availability():
             Product(id_='123', quantity=4, price_full=10, price_curr=5),
             Product(id_='123', quantity=4, price_full=10, price_curr=10),
             {
-                'price_curr': {
-                    'type': DiffType.UPDATED,
-                    'values': {'left': 5, 'right': 10},
-                }
+                'price_curr': {'left': 5, 'right': 10},
             },
             id='same product, different price_curr (reversed)',
         ),
@@ -302,17 +280,14 @@ def test_product_prop_availability():
             Product(id_='123', quantity=5, price_full=10, price_curr=10),
             Product(id_='123', quantity=0, price_full=10, price_curr=10),
             {
-                'quantity': {
-                    'type': DiffType.UPDATED,
-                    'values': {'left': 5, 'right': 0},
-                }
+                'quantity': {'left': 5, 'right': 0},
             },
             id='same product, different quantity',
         ),
     ],
 )
 def test_product_diff(product_this, product_other, diff):
-    product_diff = product_this.diff(product_other)
+    product_diff = product_this.model_diff(product_other)
     assert product_diff == diff
 
 
@@ -1053,9 +1028,169 @@ def test_item_diff_created_updated_deleted():
         ]
     )
     diff = p_old.item_diff(p_new)
-    assert diff['1']['type'] is DiffType.DELETED
-    assert diff['2']['type'] is DiffType.UPDATED
-    assert diff['3']['type'] is DiffType.CREATED
+    # Item '1' exists in old but not in new (deleted)
+    assert '1' in diff
+    assert diff['1']['name'] == {'left': 'Banana', 'right': None}
+    # Item '2' exists in both but has different quantity (updated)
+    assert '2' in diff
+    assert diff['2']['quantity'] == {'left': 2, 'right': 1}
+    # Item '3' exists in new but not in old (created)
+    assert '3' in diff
+    assert diff['3']['name'] == {'left': None, 'right': 'Orange'}
+
+
+def test_item_diff_exclude_missing():
+    """Test item_diff with exclude_missing parameter.
+
+    When exclude_missing=False (default), all item differences are included:
+    - Items only in left page (deleted)
+    - Items in both pages with different fields (updated)
+    - Items only in right page (created)
+
+    When exclude_missing=True, only items that exist in both pages are included.
+    Items that exist in only one page are excluded from the result.
+    """
+    p_left = ProductPage(
+        items=[
+            Product(id_='1', name='Apple', quantity=10, price_full=5),
+            Product(id_='2', name='Banana', quantity=5, price_full=3),
+            Product(id_='3', name='Cherry', quantity=8, price_full=7),
+        ]
+    )
+    p_right = ProductPage(
+        items=[
+            Product(id_='2', name='Banana', quantity=3, price_full=3),  # updated
+            Product(id_='3', name='Cherry', quantity=8, price_full=7),  # unchanged
+            Product(id_='4', name='Date', quantity=15, price_full=10),  # created
+        ]
+    )
+
+    # Test with exclude_missing=False (default) - includes all differences
+    diff_include = p_left.item_diff(p_right, exclude_missing=False)
+
+    assert '1' in diff_include  # Item only in left (deleted)
+    assert diff_include['1']['name'] == {'left': 'Apple', 'right': None}
+    assert diff_include['1']['quantity'] == {'left': 10, 'right': None}
+
+    assert '2' in diff_include  # Item in both with differences (updated)
+    assert diff_include['2']['quantity'] == {'left': 5, 'right': 3}
+    assert 'name' not in diff_include['2']  # name is the same
+
+    assert '3' not in diff_include  # Item in both but identical (no diff)
+
+    assert '4' in diff_include  # Item only in right (created)
+    assert diff_include['4']['name'] == {'left': None, 'right': 'Date'}
+    assert diff_include['4']['quantity'] == {'left': None, 'right': 15}
+
+    # Test with exclude_missing=True - excludes items only in one page
+    diff_exclude = p_left.item_diff(p_right, exclude_missing=True)
+
+    assert '1' not in diff_exclude  # Item only in left - excluded
+    assert '2' in diff_exclude  # Item in both with differences - included
+    assert diff_exclude['2']['quantity'] == {'left': 5, 'right': 3}
+    assert '3' not in diff_exclude  # Item in both but identical - no diff
+    assert '4' not in diff_exclude  # Item only in right - excluded
+
+
+def test_item_diff_exclude_missing_edge_cases():
+    """Test edge cases for exclude_missing parameter."""
+
+    # Test: All items only in left page
+    p_only_left = ProductPage(
+        items=[
+            Product(id_='1', name='Apple', quantity=10),
+            Product(id_='2', name='Banana', quantity=5),
+        ]
+    )
+    p_empty = ProductPage(items=[])
+
+    diff_include = p_only_left.item_diff(p_empty, exclude_missing=False)
+    assert '1' in diff_include
+    assert '2' in diff_include
+
+    diff_exclude = p_only_left.item_diff(p_empty, exclude_missing=True)
+    assert diff_exclude == {}  # All items excluded
+
+    # Test: All items only in right page
+    diff_include = p_empty.item_diff(p_only_left, exclude_missing=False)
+    assert '1' in diff_include
+    assert '2' in diff_include
+
+    diff_exclude = p_empty.item_diff(p_only_left, exclude_missing=True)
+    assert diff_exclude == {}  # All items excluded
+
+    # Test: All items exist in both pages with no differences
+    p_same_1 = ProductPage(
+        items=[
+            Product(id_='1', name='Apple', quantity=10),
+            Product(id_='2', name='Banana', quantity=5),
+        ]
+    )
+    p_same_2 = ProductPage(
+        items=[
+            Product(id_='1', name='Apple', quantity=10),
+            Product(id_='2', name='Banana', quantity=5),
+        ]
+    )
+
+    diff_include = p_same_1.item_diff(p_same_2, exclude_missing=False)
+    assert diff_include == {}
+
+    diff_exclude = p_same_1.item_diff(p_same_2, exclude_missing=True)
+    assert diff_exclude == {}
+
+    # Test: All items exist in both pages with differences
+    p_all_diff_1 = ProductPage(
+        items=[
+            Product(id_='1', name='Apple', quantity=10),
+            Product(id_='2', name='Banana', quantity=5),
+        ]
+    )
+    p_all_diff_2 = ProductPage(
+        items=[
+            Product(id_='1', name='Apple', quantity=15),
+            Product(id_='2', name='Banana', quantity=3),
+        ]
+    )
+
+    diff_include = p_all_diff_1.item_diff(p_all_diff_2, exclude_missing=False)
+    assert '1' in diff_include
+    assert '2' in diff_include
+
+    diff_exclude = p_all_diff_1.item_diff(p_all_diff_2, exclude_missing=True)
+    assert '1' in diff_exclude  # Exists in both
+    assert '2' in diff_exclude  # Exists in both
+    assert diff_exclude == diff_include  # Should be the same
+
+
+def test_item_diff_exclude_missing_with_kwargs():
+    """Test that exclude_missing works correctly with other kwargs like exclude."""
+    p1 = ProductPage(
+        items=[
+            Product(id_='1', name='Apple', category='Fruit', quantity=10),
+            Product(id_='2', name='Banana', category='Fruit', quantity=5),
+        ]
+    )
+    p2 = ProductPage(
+        items=[
+            Product(id_='2', name='Banana', category='Vegetable', quantity=3),
+            Product(id_='3', name='Carrot', category='Vegetable', quantity=7),
+        ]
+    )
+
+    # Exclude 'category' field from comparison
+    diff = p1.item_diff(p2, exclude_missing=True, exclude={'category'})
+
+    # Item '1' only in p1 - excluded due to exclude_missing
+    assert '1' not in diff
+
+    # Item '2' in both - included, but category difference should not appear
+    assert '2' in diff
+    assert 'category' not in diff['2']  # Excluded from comparison
+    assert diff['2']['quantity'] == {'left': 5, 'right': 3}
+
+    # Item '3' only in p2 - excluded due to exclude_missing
+    assert '3' not in diff
 
 
 def test_iter_item_attr_defaults_and_uniqueness():

--- a/tests/parsers/test_parsers_product.py
+++ b/tests/parsers/test_parsers_product.py
@@ -564,7 +564,7 @@ def test_validate_parsed_products(product_page_html_parse_result, product_page):
     for product in page.items:
         assert product.id_ in reference_items
         product_reference = reference_items[product.id_]
-        assert not product.diff(product_reference, exclude='recorded_at')
+        assert not product.model_diff(product_reference, exclude={'recorded_at'})
         product_ids.add(product.id_)
     # assert each product in the reference is in the parser
     assert product_ids == set(reference_items.keys())


### PR DESCRIPTION
This pull request refactors and simplifies the diffing logic for FreshPoint data models. The main change is the removal of the previous diff type system (which included diff types like CREATED, UPDATED, DELETED) in favor of a simpler approach that only records the differing values for each field. The API for comparing models and pages is updated accordingly, and all related type annotations and tests are updated to match the new structure.

Key changes include:

### Diff Logic Simplification

- Removed the diff type system (`DiffType`, `DiffValues`, and `ModelDiff`) and replaced it with a simpler `FieldDiff` structure that only contains the differing `left` and `right` values for each field. Now, the diff results are dictionaries mapping field names to `{left, right}` pairs, making the output easier to consume and reason about. [[1]](diffhunk://#diff-e133ec177444e4159c49278b0aea677838a1fc5e6e407238c14b5460bb45e957L65-L195) [[2]](diffhunk://#diff-e133ec177444e4159c49278b0aea677838a1fc5e6e407238c14b5460bb45e957R154-R166) [[3]](diffhunk://#diff-e133ec177444e4159c49278b0aea677838a1fc5e6e407238c14b5460bb45e957L300-R187) [[4]](diffhunk://#diff-e133ec177444e4159c49278b0aea677838a1fc5e6e407238c14b5460bb45e957L321-R238) [[5]](diffhunk://#diff-e133ec177444e4159c49278b0aea677838a1fc5e6e407238c14b5460bb45e957R256-R259) [[6]](diffhunk://#diff-e133ec177444e4159c49278b0aea677838a1fc5e6e407238c14b5460bb45e957L396-R301) [[7]](diffhunk://#diff-e133ec177444e4159c49278b0aea677838a1fc5e6e407238c14b5460bb45e957L419-R366)

- Updated the `BaseItem` and `BasePage` classes: the `diff` method is renamed to `model_diff` on `BaseItem`, and the `item_diff` method on `BasePage` now returns a mapping of item IDs to field difference mappings, without diff types. An `exclude_missing` parameter is added to allow filtering items missing in either page. [[1]](diffhunk://#diff-e133ec177444e4159c49278b0aea677838a1fc5e6e407238c14b5460bb45e957L300-R187) [[2]](diffhunk://#diff-e133ec177444e4159c49278b0aea677838a1fc5e6e407238c14b5460bb45e957L396-R301) [[3]](diffhunk://#diff-e133ec177444e4159c49278b0aea677838a1fc5e6e407238c14b5460bb45e957L419-R366)

### Type and API Updates

- Updated the `types` module and its exports to remove obsolete diff type classes and only export the new, simplified diff types. [[1]](diffhunk://#diff-c9793397e78ea3114fa2468fd397a705327873a87b2ddc260afc8defcdce72d0L4-R7) [[2]](diffhunk://#diff-c9793397e78ea3114fa2468fd397a705327873a87b2ddc260afc8defcdce72d0L20-R24)

- Updated documentation and docstrings throughout to reflect the new diff output structure, including code examples in docstrings. [[1]](diffhunk://#diff-e133ec177444e4159c49278b0aea677838a1fc5e6e407238c14b5460bb45e957L321-R238) [[2]](diffhunk://#diff-e133ec177444e4159c49278b0aea677838a1fc5e6e407238c14b5460bb45e957L419-R366)

### Test Adjustments

- Updated all affected tests to use the new diff structure (without diff types), and to call the new `model_diff` method instead of the removed `diff` method. [[1]](diffhunk://#diff-c561e3e0af08b1f0024e9cd79fce9c5fe3d0e01e3e509f49882b4f00a7f845baL14) [[2]](diffhunk://#diff-c561e3e0af08b1f0024e9cd79fce9c5fe3d0e01e3e509f49882b4f00a7f845baL243-R253) [[3]](diffhunk://#diff-c561e3e0af08b1f0024e9cd79fce9c5fe3d0e01e3e509f49882b4f00a7f845baL283-R290)

### Minor Improvements

- Renamed the `annotations` submodule reference in `__init__.py` to `types` for clarity and consistency.

These changes make the diffing API for models and pages more intuitive and easier to work with, and reduce unnecessary complexity in the codebase.