### PR TITLE
Update exc

### DIFF
--- a/src/freshpointparser/_utils.py
+++ b/src/freshpointparser/_utils.py
@@ -1,17 +1,10 @@
-from __future__ import annotations
-
 import logging
-from typing import Any, TypeVar
+from typing import Any
 
 from unidecode import unidecode
 
-from .exceptions import FreshPointParserValueError
-
 logger = logging.getLogger('freshpointparser')
 """Top-level logger of the ``freshpointparser`` package."""
-
-
-T = TypeVar('T')
 
 
 def normalize_text(text: Any) -> str:
@@ -23,8 +16,8 @@ def normalize_text(text: Any) -> str:
         text (Any): The text to be normalized.
 
     Raises:
-        FreshPointParserValueError: If the text cannot be normalized due to an
-            unexpected error, such as encoding issues.
+        ValueError: If the text cannot be normalized due to an unexpected error,
+            such as encoding issues.
 
     Returns:
         str: The normalized text.
@@ -34,4 +27,4 @@ def normalize_text(text: Any) -> str:
     try:
         return unidecode(str(text).strip()).casefold()
     except Exception as exc:
-        raise FreshPointParserValueError(f'Failed to normalize text "{text}".') from exc
+        raise ValueError(f'Failed to normalize text "{text}".') from exc

--- a/src/freshpointparser/exceptions.py
+++ b/src/freshpointparser/exceptions.py
@@ -5,26 +5,11 @@ class FreshPointParserError(Exception):
     """Base class for all FreshPointParser exceptions."""
 
 
-class FreshPointParserTypeError(FreshPointParserError, TypeError):
-    """Type error raised in FreshPointParser."""
-
-
-class FreshPointParserAttributeError(FreshPointParserError, AttributeError):
-    """Attribute error raised in FreshPointParser."""
-
-
-class FreshPointParserKeyError(FreshPointParserError, KeyError):
-    """Key error raised in FreshPointParser."""
-
-
-class FreshPointParserValueError(FreshPointParserError, ValueError):
-    """Value error raised in FreshPointParser."""
+class ParseError(FreshPointParserError):
+    """FreshPointParser error raised when a parsing operation fails."""
 
 
 __all__ = [
-    'FreshPointParserAttributeError',
     'FreshPointParserError',
-    'FreshPointParserKeyError',
-    'FreshPointParserTypeError',
-    'FreshPointParserValueError',
+    'ParseError',
 ]

--- a/src/freshpointparser/models/_base.py
+++ b/src/freshpointparser/models/_base.py
@@ -33,7 +33,7 @@ from pydantic import (
 )
 from pydantic.alias_generators import to_camel
 
-from ..exceptions import FreshPointParserTypeError, FreshPointParserValueError
+from ..exceptions import FreshPointParserValueError
 
 if sys.version_info >= (3, 11):
     from typing import Self, TypeAlias
@@ -475,8 +475,7 @@ class BasePage(BestEffortModel, Generic[TItem]):
                 ``'foo'``.
 
         Raises:
-            FreshPointParserTypeError: If the constraint is invalid, i.e., not a
-                Mapping or a Callable.
+            TypeError: If the constraint is not a Mapping or Callable.
 
         Returns:
             Optional[TBaseItem]: The first item on the page that matches
@@ -515,6 +514,9 @@ class BasePage(BestEffortModel, Generic[TItem]):
                 Example: ``lambda item: 'foo' in item.name`` will match items
                 where the ``name`` attribute of the item contains ``'foo'``.
 
+        Raises:
+            TypeError: If the constraint is not a Mapping or Callable.
+
         Returns:
             Iterator[TBaseItem]: A lazy iterator over all items on the page that
             match the given constraint.
@@ -531,7 +533,7 @@ class BasePage(BestEffortModel, Generic[TItem]):
                 ):
                     yield item
         else:
-            raise FreshPointParserTypeError(
+            raise TypeError(
                 f'Constraint must be either a Mapping or a Callable. '
                 f"Got type '{type(constraint).__name__}' instead."
             )

--- a/src/freshpointparser/models/_base.py
+++ b/src/freshpointparser/models/_base.py
@@ -33,8 +33,6 @@ from pydantic import (
 )
 from pydantic.alias_generators import to_camel
 
-from ..exceptions import FreshPointParserValueError
-
 if sys.version_info >= (3, 11):
     from typing import Self, TypeAlias
 else:
@@ -552,17 +550,11 @@ class BasePage(BestEffortModel, Generic[TItem]):
         Args:
             other (BasePage): The page to compare against.
             precision (Optional[Literal['s', 'm', 'h', 'd']]): The level of
-                precision for the comparison. Supported values:
-
-                - ``None``: full precision (microsecond) (default)
-                - ``s``: second precision
-                - ``m``: minute precision
-                - ``h``: hour precision
-                - ``d``: date precision
+                precision for the comparison (`None` for full precision (default),
+                's' for seconds, 'm' for minutes, 'h' for hours, and 'd' for days).
 
         Raises:
-            FreshPointParserValueError: If the precision is not one of
-                the supported values.
+            ValueError: If the precision is not one of the supported values.
 
         Returns:
             Optional[bool]: With the specified precision taken into account,
@@ -592,8 +584,9 @@ class BasePage(BestEffortModel, Generic[TItem]):
             recorded_at_self = self.recorded_at.date()
             recorded_at_other = other.recorded_at.date()
         else:
-            raise FreshPointParserValueError(
-                f"Invalid precision '{precision}'. Expected one of: 's', 'm', 'h', 'd'."
+            raise ValueError(
+                f"Invalid precision '{precision!r}'. "
+                f"Expected one of: None, 's', 'm', 'h', 'd'."
             )
         if recorded_at_self == recorded_at_other:
             return None

--- a/src/freshpointparser/models/_base.py
+++ b/src/freshpointparser/models/_base.py
@@ -372,7 +372,7 @@ class BasePage(BestEffortModel, Generic[TItem]):
         attr: str,
         *,
         unique: bool = ...,
-        unhashable: bool = ...,
+        hashable: bool = ...,
     ) -> Iterator[Any]: ...
 
     @overload
@@ -382,7 +382,7 @@ class BasePage(BestEffortModel, Generic[TItem]):
         default: T,
         *,
         unique: bool = ...,
-        unhashable: bool = ...,
+        hashable: bool = ...,
     ) -> Iterator[Union[Any, T]]: ...
 
     def iter_item_attr(
@@ -391,7 +391,7 @@ class BasePage(BestEffortModel, Generic[TItem]):
         default: Union[T, _NoDefaultType] = _NO_DEFAULT,
         *,
         unique: bool = False,
-        unhashable: bool = False,
+        hashable: bool = True,
     ) -> Iterator[Union[Any, T]]:
         """Iterate over values of a specific attribute of the page's items,
         with optional default fallback and optional uniqueness filtering.
@@ -406,15 +406,15 @@ class BasePage(BestEffortModel, Generic[TItem]):
                 If not provided, missing attributes will raise AttributeError.
             unique (bool, optional): If True, only distinct values will be
                 yielded. Defaults to False.
-            unhashable (bool, optional): If True, uniqueness is checked
+            hashable (bool, optional): If False, uniqueness is checked
                 by comparing values directly, which is useful for unhashable
-                types like lists or dictionaries, but is slower. Defaults to False.
+                types like lists or dictionaries, but is slower. Defaults to True.
 
         Raises:
-            AttributeError: If the attribute is not present in an item
-                and `default` is not provided.
-            FreshPointParserTypeError: If the attribute values are not hashable and
-                `unhashable` is set to False.
+            AttributeError: If the attribute is not present in an item and
+                ``default`` is not provided.
+            TypeError: If the attribute values are not hashable and
+                ``hashable`` is set to True.
 
         Yields:
             Iterator[Union[Any, T]]: Attribute values collected from each item
@@ -426,25 +426,18 @@ class BasePage(BestEffortModel, Generic[TItem]):
             values = (getattr(item, attr, default) for item in self.items)
 
         if unique:
-            if unhashable:
+            if hashable:
+                seen_hashable: Set[Any] = set()
+                for value in values:
+                    if value not in seen_hashable:
+                        seen_hashable.add(value)
+                        yield value
+            else:
                 seen_unhashable: List[Any] = []
                 for value in values:
                     if value not in seen_unhashable:
                         seen_unhashable.append(value)
                         yield value
-            else:
-                try:
-                    seen_hashable: Set[Any] = set()
-                    for value in values:
-                        if value not in seen_hashable:
-                            seen_hashable.add(value)
-                            yield value
-                except TypeError as err:
-                    raise FreshPointParserTypeError(
-                        f"Cannot yield unique values for attribute '{attr}': "
-                        f'the values are not hashable. '
-                        f"Set 'unhashable=True' to compare the values directly."
-                    ) from err
         else:
             yield from values
 

--- a/src/freshpointparser/models/_product.py
+++ b/src/freshpointparser/models/_product.py
@@ -443,12 +443,13 @@ class ProductPage(BasePage[Product]):
     """Name of the product location."""
 
     @property
-    def url(self) -> str:
-        """URL of the product page."""
+    def url(self) -> Optional[str]:
+        """URL of the product page.
+
+        Returns None if the location ID is not set.
+        """
         if self.location_id is None:
-            raise FreshPointParserValueError(
-                'Cannot generate product page URL: location ID is not set.'
-            )
+            return None
         return get_product_page_url(self.location_id)
 
     @property

--- a/src/freshpointparser/models/_product.py
+++ b/src/freshpointparser/models/_product.py
@@ -415,7 +415,7 @@ def get_product_page_url(location_id: Union[int, str]) -> str:
     """
     if not str(location_id).isdigit():
         raise ValueError(
-            f'Location ID must respresent a non-negative integer, got: {location_id!r}'
+            f'Location ID must represent a non-negative integer, got: {location_id!r}'
         )
     return f'https://my.freshpoint.cz/device/product-list/{location_id}'
 

--- a/src/freshpointparser/models/_product.py
+++ b/src/freshpointparser/models/_product.py
@@ -409,14 +409,14 @@ def get_product_page_url(location_id: Union[int, str]) -> str:
             the ID is 296.
 
     Raises:
-        FreshPointParserValueError: If the object does not represent a non-negative
-            integer (e.g., a negative integer, a float, or a non-numeric string).
+        ValueError: If the object does not represent a non-negative integer
+            (e.g., a negative integer, a float, or a non-numeric string).
 
     Returns:
         str: The full page URL for the given location ID.
     """
     if not str(location_id).isdigit():
-        raise FreshPointParserValueError(
+        raise ValueError(
             f'Location ID must respresent a non-negative integer, got: {location_id!r}'
         )
     return f'https://my.freshpoint.cz/device/product-list/{location_id}'

--- a/src/freshpointparser/models/_product.py
+++ b/src/freshpointparser/models/_product.py
@@ -11,8 +11,6 @@ from pydantic import (
     field_validator,
 )
 
-from freshpointparser.exceptions import FreshPointParserValueError
-
 from .._utils import normalize_text
 from ._base import BaseItem, BasePage
 

--- a/src/freshpointparser/models/_product.py
+++ b/src/freshpointparser/models/_product.py
@@ -177,7 +177,7 @@ class Product(BaseItem):
         """Validate that the current selling price is not higher than the full price."""
         price_full = info.data.get('price_full')
         if price_full is not None and price_full < price_curr:
-            raise FreshPointParserValueError(
+            raise ValueError(
                 f'Full price ({price_full}) cannot be lower than '
                 f'current price ({price_curr}).'
             )

--- a/src/freshpointparser/parsers/_location.py
+++ b/src/freshpointparser/parsers/_location.py
@@ -2,7 +2,7 @@ import json
 import re
 from typing import Any, Dict, List, Union
 
-from ..exceptions import FreshPointParserValueError
+from ..exceptions import ParseError
 from ..models import Location, LocationPage
 from ._base import BasePageHTMLParser, ParseResult
 
@@ -36,7 +36,7 @@ class LocationPageHTMLParser(BasePageHTMLParser[LocationPage]):
                 location page.
 
         Raises:
-            FreshPointParserValueError: If the location data cannot be found or parsed.
+            ParseError: If the location data cannot be found or parsed.
 
         Returns:
             List[Dict]: Raw location data dictionaries extracted from
@@ -48,7 +48,7 @@ class LocationPageHTMLParser(BasePageHTMLParser[LocationPage]):
         else:
             match_ = self._RE_SEARCH_PATTERN_BYTES.search(page_content)
         if not match_:
-            raise FreshPointParserValueError(
+            raise ParseError(
                 'Unable to find the location data in the HTML '
                 '(regex pattern not matched).'
             )
@@ -57,17 +57,17 @@ class LocationPageHTMLParser(BasePageHTMLParser[LocationPage]):
             # embedded in the HTML (a JSON string inside a JavaScript string)
             data = json.loads(json.loads(match_.group(1)))
         except IndexError as err:
-            raise FreshPointParserValueError(
+            raise ParseError(
                 'Unable to parse the location data in the HTML '
                 '(regex data group is missing).'
             ) from err
         except Exception as exc:
-            raise FreshPointParserValueError(
+            raise ParseError(
                 'Unable to parse the location data in the HTML '
                 '(Unexpected error during JSON parsing).'
             ) from exc
         if not isinstance(data, list):
-            raise FreshPointParserValueError(
+            raise ParseError(
                 'Unable to parse the location data in the HTML (data is not a list).'
             )
         return data
@@ -83,7 +83,7 @@ class LocationPageHTMLParser(BasePageHTMLParser[LocationPage]):
             location_data (Dict[str, Any]): Raw location data dictionary.
 
         Raises:
-            FreshPointParserValueError: Raised when the 'prop' key is missing or
+            ParseError: Raised when the 'prop' key is missing or
                 when other parsing errors occur.
 
         Returns:
@@ -92,13 +92,11 @@ class LocationPageHTMLParser(BasePageHTMLParser[LocationPage]):
         try:
             return Location.model_validate(location_data['prop'], context=self._context)
         except KeyError as err:
-            raise FreshPointParserValueError(
+            raise ParseError(
                 f"Missing 'prop' key in location item: {location_data}"
             ) from err
         except Exception as exc:
-            raise FreshPointParserValueError(
-                f'Error parsing location item: {location_data}'
-            ) from exc
+            raise ParseError(f'Error parsing location item: {location_data}') from exc
 
     def _parse_locations(self, page_content: Union[str, bytes]) -> List[Location]:
         """Parse multiple location items from the raw location data list.

--- a/src/freshpointparser/parsers/_product.py
+++ b/src/freshpointparser/parsers/_product.py
@@ -5,7 +5,7 @@ from typing import Callable, List, Tuple, TypeVar, Union
 import bs4
 
 from .._utils import normalize_text
-from ..exceptions import FreshPointParserKeyError, FreshPointParserValueError
+from ..exceptions import ParseError
 from ..models import Product, ProductPage
 from ._base import BasePageHTMLParser, ParseResult, logger
 
@@ -25,35 +25,6 @@ class ProductHTMLParser:
     """Regex pattern to find the quantity of a product in the HTML string."""
     _RE_PATTERN_FIND_PRICE = re.compile(r'^\d+\.\d+$')
     """Regex pattern to find the price of a product in the HTML string."""
-
-    @staticmethod
-    def _get_attr_value(attr_name: str, tag: bs4.Tag) -> str:
-        """Get the value of a specified attribute from a Tag.
-
-        Args:
-            attr_name (str): The name of the attribute to retrieve.
-            tag (bs4.Tag): The Tag to extract the attribute from.
-
-        Returns:
-            str: The value of the specified attribute.
-
-        Raises:
-            FreshPointParserKeyError: If the attribute is missing.
-            FreshPointParserValueError: If the attribute is not a string.
-        """
-        try:
-            attr = tag[attr_name]
-        except KeyError as err:
-            raise FreshPointParserKeyError(
-                f'Product attributes do not contain keyword "{attr_name}".'
-            ) from err
-        if not isinstance(attr, str):
-            raise FreshPointParserValueError(
-                f'Unexpected "{attr_name}" attribute parsing results: '
-                f'attribute value is expected to be a string '
-                f'(got type "{type(attr)}").'
-            )
-        return attr.strip()
 
     @classmethod
     def _find_id_safe(cls, product_data: bs4.Tag) -> str:
@@ -82,15 +53,39 @@ class ProductHTMLParser:
             T: The converted value.
 
         Raises:
-            FreshPointParserValueError: If an error occurs during the conversion process.
+            ParseError: If an error occurs during the conversion process.
         """
         try:
             return converter()
         except Exception as exc:
-            raise FreshPointParserValueError(
+            raise ParseError(
                 f'Unable to convert a parsed value for the product '
-                f'"id={cls._find_id_safe(product_data)}".'
+                f"with id='{cls._find_id_safe(product_data)}'."
             ) from exc
+
+    @classmethod
+    def _get_attr_value(cls, attr_name: str, tag: bs4.Tag) -> str:
+        """Get the value of a specified attribute from a Tag.
+
+        Args:
+            attr_name (str): The name of the attribute to retrieve.
+            tag (bs4.Tag): The Tag to extract the attribute from.
+
+        Returns:
+            str: The value of the specified attribute.
+
+        Raises:
+            ParseError: If the attribute is missing.
+            ParseError: If the attribute is not a string.
+        """
+        try:
+            attr = tag[attr_name]
+        except KeyError as err:
+            raise ParseError(
+                f"Data of product with id='{cls._find_id_safe(tag)}' "
+                f"does not contain keyword '{attr_name}'."
+            ) from err
+        return cls._run_converter(lambda: str(attr).strip(), tag)
 
     @classmethod
     def find_name(cls, product_data: bs4.Tag) -> str:
@@ -149,14 +144,14 @@ class ProductHTMLParser:
         """Extract the product category from the given product data."""
         category_tag = product_data.find_previous('h2')
         if category_tag is None:
-            raise FreshPointParserValueError(
+            raise ParseError(
                 f'Unable to extract product category name for product '
                 f'"id={cls._find_id_safe(product_data)}" from the provided '
                 f'html data (no preceding <h2/> tag found).'
             )
         category = category_tag.get_text(strip=True)
         if not category:
-            raise FreshPointParserValueError(
+            raise ParseError(
                 f'Unable to extract product category name for product '
                 f'"id={cls._find_id_safe(product_data)}" from the provided '
                 f'html data (the preceding <h2/> tag is empty).'
@@ -214,7 +209,7 @@ class ProductHTMLParser:
             )
             if price_curr > price_full:
                 id_ = cls._find_id_safe(product_data)
-                raise FreshPointParserValueError(
+                raise ParseError(
                     f'Unexpected product "id={id_}" parsing results: '
                     f'current price "{price_curr}" is greater than '
                     f'the regular full price "{price_full}".'
@@ -229,7 +224,7 @@ class ProductHTMLParser:
             #             f'but the "isPromo" flag is not set.'
             #             )
             return price_full, price_curr
-        raise FreshPointParserValueError(
+        raise ParseError(
             f'Unexpected number of elements in the ResultSet'
             f'(expected 1 or 2, got {len(prices)}).'
         )
@@ -252,27 +247,27 @@ class ProductPageHTMLParser(BasePageHTMLParser[ProductPage]):
                 initialized with the page HTML content.
 
         Raises:
-            FreshPointParserValueError: If the page ID cannot be parsed.
+            ParseError: If the page ID cannot be parsed.
 
         Returns:
             str: The ID number of the location.
         """
         script = bs4_parser.find(string=self._RE_PATTERN_DEVICE_ID)
         if script is None:
-            raise FreshPointParserValueError(
+            raise ParseError(
                 'Unable to parse page ID '
                 '(script tag with "deviceId" text was not found).'
             )
         match = self._RE_PATTERN_DEVICE_ID.search(script)
         if not match:
-            raise FreshPointParserValueError(
+            raise ParseError(
                 'Unable to parse page ID '
                 '("deviceId" text within the script tag was not matched).'
             )
         try:
             return str(match.group(1))
         except Exception as exc:
-            raise FreshPointParserValueError('Unable to parse page ID.') from exc
+            raise ParseError('Unable to parse page ID.') from exc
 
     def _parse_location_name(self, bs4_parser: bs4.BeautifulSoup) -> str:  # noqa: PLR6301
         """Extract the name of the location (also known as the page title)
@@ -283,20 +278,20 @@ class ProductPageHTMLParser(BasePageHTMLParser[ProductPage]):
                 initialized with the page HTML content.
 
         Raises:
-            FreshPointParserValueError: If the location name cannot be parsed.
+            ParseError: If the location name cannot be parsed.
 
         Returns:
             str: The name of the location.
         """
         title_tag = bs4_parser.find('title')
         if not title_tag:
-            raise FreshPointParserValueError(
+            raise ParseError(
                 'Unable to parse location name (<title/> tag  was not found).'
             )
         try:
             return title_tag.get_text().split('|')[0].strip()
         except Exception as exc:
-            raise FreshPointParserValueError('Unable to parse location name.') from exc
+            raise ParseError('Unable to parse location name.') from exc
 
     def _parse_product(self, product_data: bs4.Tag) -> Product:
         """Parse the a single product item to a Product model.

--- a/src/freshpointparser/parsers/_product.py
+++ b/src/freshpointparser/parsers/_product.py
@@ -76,7 +76,7 @@ class ProductHTMLParser:
 
         Raises:
             ParseError: If the attribute is missing.
-            ParseError: If the attribute is not a string.
+            ParseError: If the attribute value cannot be converted to a string.
         """
         try:
             attr = tag[attr_name]

--- a/src/freshpointparser/parsers/_product.py
+++ b/src/freshpointparser/parsers/_product.py
@@ -32,7 +32,7 @@ class ProductHTMLParser:
         is not found, catch the raised exception and return a placeholder.
         """
         try:
-            return str(cls.find_id(product_data))
+            return product_data['data-id']  # type: ignore[attr-type]
         except Exception as exc:
             logger.warning(
                 'Unable to extract product ID from the provided html data (%s).', exc

--- a/tests/models/test_models_location.py
+++ b/tests/models/test_models_location.py
@@ -365,9 +365,9 @@ def test_location_page_find_items_no_match(locations_page, constraint):
     ],
 )
 def test_location_page_find_items_invalid_constraint(locations_page, constraint):
-    with pytest.raises(Exception):  # noqa: B017
+    with pytest.raises(TypeError):
         list(locations_page.find_items(constraint))
-    with pytest.raises(Exception):  # noqa: B017
+    with pytest.raises(TypeError):
         locations_page.find_item(constraint)
 
 

--- a/tests/models/test_models_product.py
+++ b/tests/models/test_models_product.py
@@ -668,6 +668,7 @@ def test_product_page_init(page, expected_attrs):
 @pytest.mark.parametrize(
     'location_id, expected_url',
     [
+        pytest.param(None, None, id='location_id=None'),
         pytest.param(0, get_product_page_url(location_id=0), id='location_id=0'),
         pytest.param(296, get_product_page_url(location_id=296), id='location_id=296'),
     ],

--- a/tests/models/test_models_product.py
+++ b/tests/models/test_models_product.py
@@ -6,9 +6,6 @@ import pytest
 from pydantic import Field
 
 from freshpointparser import get_product_page_url
-from freshpointparser.exceptions import (
-    FreshPointParserValueError,
-)
 from freshpointparser.models import Product, ProductPage
 from freshpointparser.models.types import (
     ProductPriceUpdateInfo,
@@ -1380,7 +1377,7 @@ def test_product_page_is_newer_than(p1, p2, precision, is_p1_newer_than_p2):
 def test_is_newer_than_invalid_precision():
     p1 = ProductPage(recorded_at=datetime(2024, 1, 1))
     p2 = ProductPage(recorded_at=datetime(2024, 1, 2))
-    with pytest.raises(FreshPointParserValueError):
+    with pytest.raises(ValueError):
         p1.is_newer_than(p2, precision='q')  # type: ignore[reportArgumentType]
 
 

--- a/tests/models/test_models_product.py
+++ b/tests/models/test_models_product.py
@@ -1094,7 +1094,6 @@ def test_item_diff_exclude_missing():
 
 def test_item_diff_exclude_missing_edge_cases():
     """Test edge cases for exclude_missing parameter."""
-
     # Test: All items only in left page
     p_only_left = ProductPage(
         items=[
@@ -1226,17 +1225,16 @@ def test_iter_item_attr_defaults_and_uniqueness():
 
     # unique with unhashable values
     page.items.append(SubProduct(id_='5', context={'key': 'value'}))
-    assert list(page.iter_item_attr('context', default={}, unhashable=True)) == [
-        {},
-        {},
-        {},
+    assert list(
+        page.iter_item_attr('context', default={}, unique=True, hashable=False)
+    ) == [
         {},
         {'key': 'value'},
     ]
 
-    # TypeError on unhashable unique without flag
-    with pytest.raises(AttributeError):
-        list(page.iter_item_attr('context', unique=True))
+    # TypeError on unhashable unique without hashable=False
+    with pytest.raises(TypeError):
+        list(page.iter_item_attr('context', default={}, unique=True))
 
 
 @pytest.mark.parametrize(

--- a/tests/models/test_models_product.py
+++ b/tests/models/test_models_product.py
@@ -980,9 +980,9 @@ def test_product_page_find_items_no_match(product_page, constraint):
     ],
 )
 def test_product_page_find_items_invalid_constraint(product_page, constraint):
-    with pytest.raises(Exception):  # noqa: B017
+    with pytest.raises(TypeError):
         list(product_page.find_items(constraint))
-    with pytest.raises(Exception):  # noqa: B017
+    with pytest.raises(TypeError):
         product_page.find_item(constraint)
 
 

--- a/tests/parsers/test_parsers_base.py
+++ b/tests/parsers/test_parsers_base.py
@@ -3,9 +3,7 @@ from typing import Union
 
 import pytest
 
-from freshpointparser.exceptions import (
-    FreshPointParserValueError,
-)
+from freshpointparser.exceptions import ParseError
 from freshpointparser.models._base import BasePage
 from freshpointparser.parsers._base import BasePageHTMLParser
 
@@ -23,9 +21,7 @@ class DummyPageHTMLParserWithErrors(BasePageHTMLParser[BasePage]):
         if isinstance(page_content, str):
             page_content = page_content.encode('utf-8', errors='ignore')
         if b'error' in page_content:
-            self._context.register_error(
-                FreshPointParserValueError('Simulated parsing error')
-            )
+            self._context.register_error(ParseError('Simulated parsing error'))
         data = {'recorded_at': datetime.now()}
         return BasePage.model_validate(data, context=self._context)
 
@@ -165,7 +161,7 @@ def test_parse_errors_collected_in_metadata():
     result = parser.parse('<html>error here</html>')
 
     assert len(result.metadata.errors) == 1
-    assert isinstance(result.metadata.errors[0], FreshPointParserValueError)
+    assert isinstance(result.metadata.errors[0], ParseError)
 
 
 def test_parse_errors_cleared_on_successful_parse():
@@ -213,13 +209,13 @@ def test_safe_parse_method():
 
     # Test with FreshPointParserError
     def error_func() -> None:
-        raise FreshPointParserValueError('Test error')
+        raise ParseError('Test error')
 
     parser = DummyPageHTMLParser()
     result = parser._safe_parse(error_func)
     assert result is None
     assert len(parser._context.errors) == 1
-    assert isinstance(parser._context.errors[0], FreshPointParserValueError)
+    assert isinstance(parser._context.errors[0], ParseError)
 
 
 def test_safe_parse_non_freshpoint_error_propagates():

--- a/tests/parsers/test_parsers_location.py
+++ b/tests/parsers/test_parsers_location.py
@@ -5,9 +5,7 @@ from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
 
 from freshpointparser import parse_location_page
-from freshpointparser.exceptions import (
-    FreshPointParserValueError,
-)
+from freshpointparser.exceptions import ParseError
 from freshpointparser.models import Location, LocationPage
 from freshpointparser.parsers import LocationPageHTMLParser
 
@@ -66,17 +64,17 @@ def location_page_expected_meta(location_page_metadata_json_content):
 def test_load_json_errors():
     parser = LocationPageHTMLParser()
     # pattern not found
-    with pytest.raises(FreshPointParserValueError):
+    with pytest.raises(ParseError):
         parser._load_json('<html></html>')
 
     # invalid JSON in the matched text
     faulty = 'devices = "[{]" ;'
-    with pytest.raises(FreshPointParserValueError):
+    with pytest.raises(ParseError):
         parser._load_json(faulty)
 
     # data not a list
     not_list = 'devices = "{}";'
-    with pytest.raises(FreshPointParserValueError):
+    with pytest.raises(ParseError):
         parser._load_json(not_list)
 
 
@@ -184,7 +182,7 @@ def test_parse_location_missing_prop_key():
     """Test _parse_location raises error when 'prop' key is missing."""
     parser = LocationPageHTMLParser()
     location_data = {'location': {}}
-    with pytest.raises(FreshPointParserValueError) as exc_info:
+    with pytest.raises(ParseError) as exc_info:
         parser._parse_location(location_data)
     assert "Missing 'prop' key" in str(exc_info.value)
 
@@ -244,7 +242,7 @@ def test_parse_locations_partial_failure():
     assert locations[1].name == 'Valid 2'
     # Error should be collected in context
     assert len(parser._context.errors) == 1
-    assert isinstance(parser._context.errors[0], FreshPointParserValueError)
+    assert isinstance(parser._context.errors[0], ParseError)
 
 
 def test_parse_locations_all_invalid():
@@ -338,7 +336,7 @@ def test_parse_errors_collected_in_metadata():
     result = parser.parse(html_content)
     # Check that errors were collected
     assert len(result.metadata.errors) > 0
-    assert isinstance(result.metadata.errors[0], FreshPointParserValueError)
+    assert isinstance(result.metadata.errors[0], ParseError)
 
 
 def test_parse_location_page_function(location_page_html_content):

--- a/tests/parsers/test_parsers_product.py
+++ b/tests/parsers/test_parsers_product.py
@@ -7,10 +7,7 @@ from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
 
 from freshpointparser import parse_product_page
-from freshpointparser.exceptions import (
-    FreshPointParserKeyError,
-    FreshPointParserValueError,
-)
+from freshpointparser.exceptions import ParseError
 from freshpointparser.models import Product, ProductPage
 from freshpointparser.parsers import ProductPageHTMLParser
 from freshpointparser.parsers._product import ProductHTMLParser
@@ -100,7 +97,7 @@ def test_find_name_with_html_entities():
 def test_find_name_missing_attribute():
     """Test error when data-name attribute is missing."""
     tag = bs4.BeautifulSoup('<div></div>', 'lxml').div
-    with pytest.raises(FreshPointParserKeyError) as exc_info:
+    with pytest.raises(ParseError) as exc_info:
         ProductHTMLParser.find_name(tag)  # type: ignore
     assert 'data-name' in str(exc_info.value)
 
@@ -118,7 +115,7 @@ def test_find_id_missing_attribute():
     """Test error when data-id attribute is missing."""
     tag = bs4.BeautifulSoup('<div></div>', 'lxml').div
     assert tag is not None
-    with pytest.raises(FreshPointParserKeyError):
+    with pytest.raises(ParseError):
         ProductHTMLParser.find_id(tag)
 
 
@@ -206,7 +203,7 @@ def test_find_category_success():
 def test_find_category_missing_h2():
     """Test error when no preceding h2 tag exists."""
     tag = bs4.BeautifulSoup('<div data-id="1"></div>', 'lxml').div
-    with pytest.raises(FreshPointParserValueError) as exc_info:
+    with pytest.raises(ParseError) as exc_info:
         ProductHTMLParser.find_category(tag)  # type: ignore
     assert 'no preceding <h2/> tag' in str(exc_info.value)
 
@@ -215,7 +212,7 @@ def test_find_category_empty_h2():
     """Test error when preceding h2 tag is empty."""
     soup = bs4.BeautifulSoup('<h2>  </h2><div data-id="1"></div>', 'lxml')
     tag = soup.find('div')
-    with pytest.raises(FreshPointParserValueError) as exc_info:
+    with pytest.raises(ParseError) as exc_info:
         ProductHTMLParser.find_category(tag)  # type: ignore
     assert 'empty' in str(exc_info.value)
 
@@ -280,7 +277,7 @@ def test_find_price_invalid_order():
         '<div class="product" data-id="1"><span>50.00</span><span>100.00</span></div>',
         'lxml',
     ).div
-    with pytest.raises(FreshPointParserValueError) as exc_info:
+    with pytest.raises(ParseError) as exc_info:
         ProductHTMLParser.find_price(tag)  # type: ignore
     assert 'greater than' in str(exc_info.value)
 
@@ -291,7 +288,7 @@ def test_find_price_too_many():
         '<div class="product"><span>100.00</span><span>75.00</span><span>50.00</span></div>',
         'lxml',
     ).div
-    with pytest.raises(FreshPointParserValueError) as exc_info:
+    with pytest.raises(ParseError) as exc_info:
         ProductHTMLParser.find_price(tag)  # type: ignore
     assert 'expected 1 or 2' in str(exc_info.value)
 
@@ -315,7 +312,7 @@ def test_get_attr_value_with_whitespace():
 def test_get_attr_value_missing():
     """Test _get_attr_value raises error for missing attribute."""
     tag = bs4.BeautifulSoup('<div></div>', 'lxml').div
-    with pytest.raises(FreshPointParserKeyError):
+    with pytest.raises(ParseError):
         ProductHTMLParser._get_attr_value('missing-attr', tag)  # type: ignore
 
 
@@ -339,7 +336,7 @@ def test_parse_location_id_no_script():
     parser = ProductPageHTMLParser()
     html = '<html></html>'
     bs4_parser = bs4.BeautifulSoup(html, 'lxml')
-    with pytest.raises(FreshPointParserValueError) as exc_info:
+    with pytest.raises(ParseError) as exc_info:
         parser._parse_location_id(bs4_parser)
     assert 'script tag' in str(exc_info.value)
 
@@ -349,7 +346,7 @@ def test_parse_location_id_no_match():
     parser = ProductPageHTMLParser()
     html = '<script>var other = "123";</script>'
     bs4_parser = bs4.BeautifulSoup(html, 'lxml')
-    with pytest.raises(FreshPointParserValueError) as exc_info:
+    with pytest.raises(ParseError) as exc_info:
         parser._parse_location_id(bs4_parser)
     assert 'deviceId' in str(exc_info.value)
 
@@ -368,7 +365,7 @@ def test_parse_location_name_no_title():
     parser = ProductPageHTMLParser()
     html = '<html></html>'
     bs4_parser = bs4.BeautifulSoup(html, 'lxml')
-    with pytest.raises(FreshPointParserValueError) as exc_info:
+    with pytest.raises(ParseError) as exc_info:
         parser._parse_location_name(bs4_parser)
     assert 'title' in str(exc_info.value).lower()
 


### PR DESCRIPTION
This pull request refactors error handling throughout the codebase by removing custom exception classes that simply wrapped standard Python exceptions. Now, standard exceptions like `ValueError` and `TypeError` are raised directly, and a new `ParseError` is introduced specifically for parsing failures. The changes also clarify and simplify documentation and function signatures, and adjust the logic for handling hashable/unhashable attribute uniqueness.

**Exception Handling Refactor:**

* Removed custom exceptions such as `FreshPointParserValueError`, `FreshPointParserTypeError`, `FreshPointParserKeyError`, and `FreshPointParserAttributeError`, replacing them with standard exceptions (`ValueError`, `TypeError`) throughout the codebase. [[1]](diffhunk://#diff-c40b54d8ff8a3b61d75ac5005b4762b065eb264929ab295062da85289c0780dcL1-L16) [[2]](diffhunk://#diff-3627ac0040aca29aa1fef42239b127d8434b27f902c48ff805d939101652e555L8-R14) [[3]](diffhunk://#diff-e133ec177444e4159c49278b0aea677838a1fc5e6e407238c14b5460bb45e957L36-L37) [[4]](diffhunk://#diff-755e4c33a3c9985221a42204a5d8ef029b1ba78e8b89138bccd0f716c731c331L14-L15) [[5]](diffhunk://#diff-6295fa7a553a7384c71c3d7aed64d3130794fc03f8a7f2faf9f004613635e665L5-R5) [[6]](diffhunk://#diff-f2a3be9279566a10a5b803e8524ab027091ce8041bd85ca584f28b1b47d6803aL8-R8)
* Introduced a new `ParseError` exception for parsing-related errors and updated all relevant parsing code to use this exception. [[1]](diffhunk://#diff-3627ac0040aca29aa1fef42239b127d8434b27f902c48ff805d939101652e555L8-R14) [[2]](diffhunk://#diff-6295fa7a553a7384c71c3d7aed64d3130794fc03f8a7f2faf9f004613635e665L5-R5) [[3]](diffhunk://#diff-6295fa7a553a7384c71c3d7aed64d3130794fc03f8a7f2faf9f004613635e665L39-R39) [[4]](diffhunk://#diff-6295fa7a553a7384c71c3d7aed64d3130794fc03f8a7f2faf9f004613635e665L51-R51) [[5]](diffhunk://#diff-6295fa7a553a7384c71c3d7aed64d3130794fc03f8a7f2faf9f004613635e665L60-R70) [[6]](diffhunk://#diff-6295fa7a553a7384c71c3d7aed64d3130794fc03f8a7f2faf9f004613635e665L86-R86) [[7]](diffhunk://#diff-6295fa7a553a7384c71c3d7aed64d3130794fc03f8a7f2faf9f004613635e665L95-R99)

**API and Documentation Improvements:**

* Updated all docstrings and error messages to reflect the use of standard exceptions, improving clarity and accuracy in the documentation. [[1]](diffhunk://#diff-c40b54d8ff8a3b61d75ac5005b4762b065eb264929ab295062da85289c0780dcL26-R20) [[2]](diffhunk://#diff-e133ec177444e4159c49278b0aea677838a1fc5e6e407238c14b5460bb45e957L485-R476) [[3]](diffhunk://#diff-e133ec177444e4159c49278b0aea677838a1fc5e6e407238c14b5460bb45e957R515-R517) [[4]](diffhunk://#diff-e133ec177444e4159c49278b0aea677838a1fc5e6e407238c14b5460bb45e957L560-R557) [[5]](diffhunk://#diff-755e4c33a3c9985221a42204a5d8ef029b1ba78e8b89138bccd0f716c731c331L412-R417) [[6]](diffhunk://#diff-6295fa7a553a7384c71c3d7aed64d3130794fc03f8a7f2faf9f004613635e665L39-R39) [[7]](diffhunk://#diff-6295fa7a553a7384c71c3d7aed64d3130794fc03f8a7f2faf9f004613635e665L86-R86)
* Changed the `url` property of `ProductPage` to return `None` instead of raising an error when the location ID is not set, simplifying its usage.

**Logic and Signature Adjustments:**

* Replaced the `unhashable` parameter with `hashable` (with opposite logic and updated default) in the `iter_item_attr` method, clarifying its intent and usage. [[1]](diffhunk://#diff-e133ec177444e4159c49278b0aea677838a1fc5e6e407238c14b5460bb45e957L375-R373) [[2]](diffhunk://#diff-e133ec177444e4159c49278b0aea677838a1fc5e6e407238c14b5460bb45e957L385-R383) [[3]](diffhunk://#diff-e133ec177444e4159c49278b0aea677838a1fc5e6e407238c14b5460bb45e957L394-R392) [[4]](diffhunk://#diff-e133ec177444e4159c49278b0aea677838a1fc5e6e407238c14b5460bb45e957L409-R415) [[5]](diffhunk://#diff-e133ec177444e4159c49278b0aea677838a1fc5e6e407238c14b5460bb45e957L429-R438)
* Updated all relevant function signatures and error handling logic to match the new exception usage and parameter naming. [[1]](diffhunk://#diff-e133ec177444e4159c49278b0aea677838a1fc5e6e407238c14b5460bb45e957L485-R476) [[2]](diffhunk://#diff-e133ec177444e4159c49278b0aea677838a1fc5e6e407238c14b5460bb45e957R515-R517) [[3]](diffhunk://#diff-e133ec177444e4159c49278b0aea677838a1fc5e6e407238c14b5460bb45e957L541-R534) [[4]](diffhunk://#diff-e133ec177444e4159c49278b0aea677838a1fc5e6e407238c14b5460bb45e957L600-R589) [[5]](diffhunk://#diff-755e4c33a3c9985221a42204a5d8ef029b1ba78e8b89138bccd0f716c731c331L180-R178)

**Code Cleanup:**

* Removed unused imports and code related to the deleted custom exceptions. [[1]](diffhunk://#diff-c40b54d8ff8a3b61d75ac5005b4762b065eb264929ab295062da85289c0780dcL1-L16) [[2]](diffhunk://#diff-755e4c33a3c9985221a42204a5d8ef029b1ba78e8b89138bccd0f716c731c331L14-L15) [[3]](diffhunk://#diff-f2a3be9279566a10a5b803e8524ab027091ce8041bd85ca584f28b1b47d6803aL8-R8)